### PR TITLE
Fix cron scheduling and timezone handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Installiere cron
-RUN apt-get update && apt-get -y install cron
+RUN apt-get update && apt-get -y install cron tzdata && rm -rf /var/lib/apt/lists/*
 
 # Kopiere das Entrypoint-Skript und mache es ausführbar
 COPY entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Installiere cron
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install cron tzdata && rm -rf /var/lib/apt/lists/*
 
 # Kopiere das Entrypoint-Skript und mache es ausführbar

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ docker run --name idle-outpost-claimer -d \
   ghcr.io/cancel-cloud/idleoutpostclaimer:latest
 ```
 
-Das war's! Der Container läuft nun im Hintergrund (`-d` Flag) und führt den Claim-Prozess täglich um 02:00 Uhr nachts aus.
+Das war's! Der Container läuft nun im Hintergrund (`-d` Flag) und führt den Claim-Prozess täglich um 02:00 Uhr aus.
+Die Zeit bezieht sich standardmäßig auf die UTC-Zeitzone. 
+Möchtest du eine andere Zone verwenden, kannst du die Umgebungsvariable `TZ` setzen (z.B. `-e TZ=Europe/Berlin`).
 
 ## 🪵 Logs einsehen
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       # Dieser Wert muss in der Portainer UI oder in einer .env-Datei gesetzt werden
       - USER_GAME_ID=${USER_GAME_ID}
+      # Optional: setzt die Zeitzone des Containers
+      - TZ=${TZ}
     volumes:
       # Persistiert die Log-Dateien in einem benannten Volume
       - idle-outpost-logs:/var/log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,11 @@
 set -e
 
 # Optional: Zeitzone setzen
-if [ -n "$TZ" ]; then
+if [ -n "$TZ" ] && [ -f "/usr/share/zoneinfo/$TZ" ]; then
   ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
   echo "$TZ" > /etc/timezone
+else
+  echo "Invalid timezone: $TZ. Skipping timezone configuration." >&2
 fi
 
 # Cron-Job samt Umgebungsvariable konfigurieren


### PR DESCRIPTION
## Summary
- ensure cron job runs under root user and include USER_GAME_ID
- allow configuring timezone via `TZ` and add tzdata package
- document UTC timezone and optional `TZ` variable
- expose `TZ` in docker-compose

## Testing
- `python3 -m py_compile app.py`
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6876104ace68832c80d42ff1bc335428